### PR TITLE
feat(core): fallback to classname as componentname

### DIFF
--- a/packages/core/src/GondelDecorators.test.ts
+++ b/packages/core/src/GondelDecorators.test.ts
@@ -32,6 +32,13 @@ describe("GondelDecorators", () => {
       const button = createMockElement("t");
       expect(button.constructor).toBe(Button);
     });
+
+    it("should add the component for wihtout a namespace invoking the class name", () => {
+      @Component()
+      class Button extends GondelBaseComponent {}
+      const button = createMockElement("g");
+      expect(button.constructor).toBe(Button);
+    });
   });
 
   describe("#event - e2e", () => {

--- a/packages/core/src/GondelDecorators.ts
+++ b/packages/core/src/GondelDecorators.ts
@@ -6,9 +6,9 @@ import { addRootEventListener, removeRootEventListernerForComponent } from "./Go
 import { addGondelPluginEventListener } from "./GondelPluginUtils";
 import { registerComponent } from "./index";
 
-export function Component(componentName: string, namespace?: string) {
+export function Component(componentName?: string, namespace?: string) {
   return function(constructor: IGondelComponent) {
-    registerComponent(componentName, namespace, constructor);
+    registerComponent(componentName || constructor.name, namespace, constructor);
   };
 }
 


### PR DESCRIPTION
To make it easier to spawn a component i want the ComponentName to be optional and to get the ClassName as default.

* Enhancement

## What changes did you make?

I made the componentName optional and invoked the className as default.

## Does this pull request introduce a breaking change?

no!
