### PR TITLE
docs: Use react render function instead of class inside the usage example

### DIFF
--- a/examples/gondel-react/src/components/App.tsx
+++ b/examples/gondel-react/src/components/App.tsx
@@ -7,8 +7,6 @@ type Props = {
   title: string;
 };
 
-export class ReactApp extends React.Component<Props, {}> {
-  render() {
-    return <AwesomeButton type="primary">{this.props.title}</AwesomeButton>;
-  }
-}
+export const ReactApp = (props: Props) => {
+  return <AwesomeButton type="primary">{props.title}</AwesomeButton>;
+};


### PR DESCRIPTION
lets use the function syntax to simplify the demo:

```js

type Props = {
  title: string;
};

export const ReactApp = (props: Props) => {
  return <AwesomeButton type="primary">{props.title}</AwesomeButton>;
};

```